### PR TITLE
Rename(command_error_handling): The command error handling enum

### DIFF
--- a/include/command_error_handling.h
+++ b/include/command_error_handling.h
@@ -9,8 +9,8 @@
 
 typedef enum is_existing_e {
     NOT_EXISTING,
-    ACCESSABLE,
-    NOT_ACCESSABLE,
+    ACCESSIBLE,
+    NOT_ACCESSIBLE,
     ERROR
 } is_existing_t;
 

--- a/src/execution/command_error_handling.c
+++ b/src/execution/command_error_handling.c
@@ -18,9 +18,9 @@ static int check_access(char *cmd, bool *not_access)
     if (access(cmd, F_OK) == 0) {
         if (access(cmd, X_OK) != 0) {
             *not_access = true;
-            return NOT_ACCESSABLE;
+            return NOT_ACCESSIBLE;
         }
-        return ACCESSABLE;
+        return ACCESSIBLE;
     }
     return NOT_EXISTING;
 }
@@ -51,7 +51,7 @@ static char *exist_in_path(char *cmd, char *path, int *error)
     }
     for (int i = 0; path_tab[i] != NULL; i++) {
         tmp = get_tmp(path_tab[i], cmd);
-        if (check_access(tmp, &not_access) == ACCESSABLE) {
+        if (check_access(tmp, &not_access) == ACCESSIBLE) {
             destroy_array(path_tab);
             return tmp;
         }


### PR DESCRIPTION
Rename some enums of the command error handling into good english words
Closes #59 