### PR TITLE
Delete(get_string): Remove free cause segfault

### DIFF
--- a/src/ncurse/get_string.c
+++ b/src/ncurse/get_string.c
@@ -29,7 +29,6 @@ static void get_keyboard_event(int ch, char *save, char *line, int len)
             return;
         line[len] = (char)ch;
         line[len + 1] = '\0';
-        free(save);
         save = strdup(line);
     }
 }


### PR DESCRIPTION
Je ne sais pas pourquoi, mais je crois que c'est ce free qui est la cause du segfault report sur discord. Je sais pas si le retiré fera du problème de mémoire, mais je pense que c'est la cause du segfault.