### PR TITLE
Fix(pipe_gestion.c): Fix the redirection of the final output to the n…

### DIFF
--- a/src/parser/pipe_gestion.c
+++ b/src/parser/pipe_gestion.c
@@ -26,7 +26,7 @@ void pipes_stuff_child(pipe_t *pipes)
         for (int i = 0; i < pipes->max * 2; i++) {
             close(pipes->fds[i]);
         }
-    } if (pipes->index == pipes->max) {
+    } if (pipes->index == pipes->max && isatty(0) == 1) {
         fd = open(get_term_name(), O_RDWR | O_APPEND);
         if (fd == -1)
             exit(84);


### PR DESCRIPTION
…ormal terminal when the ncurses is off.
il manquait un isatty pour le display final qui avait ete retiré lors des pipes par inadvertance maintent un "echo ls | ./42sh" refonctionne :)