### PR TITLE
Fix(get_string): Fix segmentation fault

### DIFF
--- a/src/ncurse/get_string.c
+++ b/src/ncurse/get_string.c
@@ -21,14 +21,14 @@ static void get_keyboard_event(int ch, char **save, char **line, size_t len)
         *line = realloc(*line, sizeof(char) * (len));
         if (*line == NULL)
             return;
-        *line[len - 1] = '\0';
+        (*line)[len - 1] = '\0';
     }
     if (PRINTABLE(ch)) {
-        *line = realloc(*line, sizeof(char) * (len + 2));
+        (*line) = realloc(*line, sizeof(char) * (len + 2));
         if (*line == NULL)
             return;
-        *line[len] = (char)ch;
-        *line[len + 1] = '\0';
+        (*line)[len] = (char)ch;
+        (*line)[len + 1] = '\0';
         *save = strdup(*line);
     }
 }


### PR DESCRIPTION
Urgent fix. Fix segfault when we do backspace at the middle of one line.